### PR TITLE
Added support for opcodes and their respective tests

### DIFF
--- a/pliron-clif/src/from_clif_ir.rs
+++ b/pliron-clif/src/from_clif_ir.rs
@@ -637,4 +637,74 @@ mod tests {
         );
         }
     }
+
+    #[test]
+    fn test_ineg_fn_convert_clif_to_pliron() {
+        let clif_code = r#"
+    function %ineg(i32) -> i32 apple_aarch64 {
+        block0(v0: i32):
+            v1 = ineg v0
+            return v1
+    }
+    "#;
+
+        let functions = parse_functions(clif_code).expect("Failed to parse .clif");
+
+        for func in functions {
+            let mut cctx = ConversionCtx::default();
+            let mut ctx = Context::new();
+            builtin::register(&mut ctx);
+            crate::register(&mut ctx);
+            let func_op = match convert_function(&mut ctx, &mut cctx, func) {
+                Ok(op) => op,
+                Err(e) => panic!("Error: {}", e),
+            };
+            let print_func = func_op.disp(&ctx);
+            println!("{}", print_func);
+            assert_eq!(
+                "builtin.func @ineg: builtin.function <(builtin.int <si32>)->(builtin.int <si32>)> 
+{
+  ^entry_block_1v1(block_1v1_arg0:builtin.int <si32>):
+    op_2v1_res0 = clif.ineg block_1v1_arg0:builtin.int <si32>;
+    clif.return (op_2v1_res0)
+}",
+                format!("{}", print_func)
+            );
+        }
+    }
+
+    #[test]
+    fn test_umax_fn_convert_clif_to_pliron() {
+        let clif_code = r#"
+    function %umax(i32, i32) -> i32 apple_aarch64 {
+        block0(v0: i32, v1: i32):
+            v2 = umax v0, v1
+            return v2
+    }
+    "#;
+
+        let functions = parse_functions(clif_code).expect("Failed to parse .clif");
+
+        for func in functions {
+            let mut cctx = ConversionCtx::default();
+            let mut ctx = Context::new();
+            builtin::register(&mut ctx);
+            crate::register(&mut ctx);
+            let func_op = match convert_function(&mut ctx, &mut cctx, func) {
+                Ok(op) => op,
+                Err(e) => panic!("Error: {}", e),
+            };
+            let print_func = func_op.disp(&ctx);
+            println!("{}", print_func);
+            assert_eq!(
+            "builtin.func @umax: builtin.function <(builtin.int <si32>, builtin.int <si32>)->(builtin.int <si32>)> 
+{
+  ^entry_block_1v1(block_1v1_arg0:builtin.int <si32>,block_1v1_arg1:builtin.int <si32>):
+    op_2v1_res0 = clif.umax block_1v1_arg0,block_1v1_arg1:builtin.int <si32>;
+    clif.return (op_2v1_res0)
+}",
+            format!("{}", print_func)
+        );
+        }
+    }
 }

--- a/pliron-clif/src/from_clif_ir.rs
+++ b/pliron-clif/src/from_clif_ir.rs
@@ -26,8 +26,8 @@ use cranelift_codegen::{
 use rustc_hash::FxHashMap;
 
 use crate::{
-    op_interfaces::BinArithOp,
-    ops::{IAddOp, ReturnOp},
+    op_interfaces::{BinArithOp, UnaryArithOp},
+    ops::{IAddOp, IabsOp, InegOp, ReturnOp, UmaxOp, UminOp},
 };
 
 /// Converts a slice of [ClifValue]s to Pliron's [PlironValue]s.
@@ -112,6 +112,30 @@ fn convert_instruction(
             let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
             let iadd_op = IAddOp::new(ctx, operands[0], operands[1]);
             let op = iadd_op.get_operation();
+            return Ok(op);
+        }
+        Opcode::Umin => {
+            let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
+            let umin_op = UminOp::new(ctx, operands[0], operands[1]);
+            let op = umin_op.get_operation();
+            return Ok(op);
+        }
+        Opcode::Umax => {
+            let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
+            let umax_op = UmaxOp::new(ctx, operands[0], operands[1]);
+            let op = umax_op.get_operation();
+            return Ok(op);
+        }
+        Opcode::Ineg => {
+            let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
+            let ineg_op = InegOp::new(ctx, operands[0]);
+            let op = ineg_op.get_operation();
+            return Ok(op);
+        }
+        Opcode::Iabs => {
+            let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
+            let iabs_op = IabsOp::new(ctx, operands[0]);
+            let op = iabs_op.get_operation();
             return Ok(op);
         }
         Opcode::Return => match inst_args.len() {
@@ -576,6 +600,41 @@ mod tests {
     clif.return (op_2v1_res0)
 }", format!("{}", print_func)
             );
+        }
+    }
+
+    #[test]
+    fn test_umin_fn_convert_clif_to_pliron() {
+        let clif_code = r#"
+    function %umin(i32, i32) -> i32 apple_aarch64 {
+        block0(v0: i32, v1: i32):
+            v2 = umin v0, v1
+            return v2
+    }
+    "#;
+
+        let functions = parse_functions(clif_code).expect("Failed to parse .clif");
+
+        for func in functions {
+            let mut cctx = ConversionCtx::default();
+            let mut ctx = Context::new();
+            builtin::register(&mut ctx);
+            crate::register(&mut ctx);
+            let func_op = match convert_function(&mut ctx, &mut cctx, func) {
+                Ok(op) => op,
+                Err(e) => panic!("Error: {}", e),
+            };
+            let print_func = func_op.disp(&ctx);
+            println!("{}", print_func);
+            assert_eq!(
+            "builtin.func @umin: builtin.function <(builtin.int <si32>, builtin.int <si32>)->(builtin.int <si32>)> 
+{
+  ^entry_block_1v1(block_1v1_arg0:builtin.int <si32>,block_1v1_arg1:builtin.int <si32>):
+    op_2v1_res0 = clif.umin block_1v1_arg0,block_1v1_arg1:builtin.int <si32>;
+    clif.return (op_2v1_res0)
+}",
+            format!("{}", print_func)
+        );
         }
     }
 }

--- a/pliron-clif/src/from_clif_ir.rs
+++ b/pliron-clif/src/from_clif_ir.rs
@@ -665,7 +665,7 @@ mod tests {
                 "builtin.func @ineg: builtin.function <(builtin.int <si32>)->(builtin.int <si32>)> 
 {
   ^entry_block_1v1(block_1v1_arg0:builtin.int <si32>):
-    op_2v1_res0 = clif.ineg block_1v1_arg0:builtin.int <si32>;
+    op_2v1_res0 = clif.ineg block_1v1_arg0;
     clif.return (op_2v1_res0)
 }",
                 format!("{}", print_func)

--- a/pliron-clif/src/from_clif_ir.rs
+++ b/pliron-clif/src/from_clif_ir.rs
@@ -1,3 +1,5 @@
+// Import required types and modules from Pliron and Cranelift.
+// Pliron imports: Basic IR entities such as context, operations, regions, types, etc.
 use pliron::{
     basic_block::BasicBlock,
     builtin::{
@@ -15,6 +17,7 @@ use pliron::{
     value::Value as PlironValue,
 };
 
+// Cranelift imports: Provide IR structures and analysis tools for Cranelift IR.
 use cranelift_codegen::{
     dominator_tree::DominatorTree,
     flowgraph::ControlFlowGraph,
@@ -23,46 +26,51 @@ use cranelift_codegen::{
         Value as ClifValue, ValueDef,
     },
 };
+// Import a fast hash map from rustc_hash crate.
 use rustc_hash::FxHashMap;
 
+// Import our own modules that define op interfaces and operations.
 use crate::{
     op_interfaces::{BinArithOp, UnaryArithOp},
-    ops::{IAddOp, IabsOp, InegOp, ReturnOp, UmaxOp, UminOp},
+    ops::{IAddOp, ISubOp, IabsOp, InegOp, ReturnOp, UmaxOp, UminOp},
 };
 
-/// Converts a slice of [ClifValue]s to Pliron's [PlironValue]s.
+/// Converts a slice of Cranelift IR values ([ClifValue]) into Pliron IR values ([PlironValue]).
 ///
-/// This function processes each operand, determining if it is defined by an instruction or
-/// a block parameter, and converts it into the corresponding `PlironValue`.
+/// This function iterates over the provided Cranelift operands, determines whether each operand
+/// is defined by an instruction result or a block parameter, and converts it accordingly.
 ///
 /// # Arguments
-/// - `ctx`: The Pliron context for creating IR entities.
-/// - `dfg`: The data flow graph containing the original operand definitions.
-/// - `cctx`: The conversion context for caching converted entities.
-/// - `operands`: The slice of `ClifValue` to convert.
+/// - `ctx`: The Pliron context used to create or lookup IR entities.
+/// - `dfg`: The Cranelift Data Flow Graph that holds definitions for values.
+/// - `cctx`: The conversion context which caches already converted entities.
+/// - `operands`: A slice of Cranelift values to be converted.
 ///
 /// # Returns
-/// A `Result` containing a vector of converted `PlironValue` or an error if conversion fails.
+/// A Result containing a vector of converted [PlironValue]s or an error if conversion fails.
 ///
 /// # Panics
-/// Panics if a `Union` value definition is encountered, as it is not yet implemented.
+/// Panics if a `Union` value definition is encountered (not yet implemented).
 fn convert_operands(
     ctx: &mut Context,
     dfg: &DataFlowGraph,
     cctx: &mut ConversionCtx,
     operands: &[ClifValue],
 ) -> Result<Vec<PlironValue>> {
+     // Preallocate a vector with the capacity of the operands length.
     let mut pliron_operands = Vec::with_capacity(operands.len());
     for operand in operands {
         let operand_def = dfg.value_def(*operand);
         match operand_def {
-            // Is this a value defined by an instruction? If so, convert instruction result
+            // If the value is defined as a result of an instruction:
+            // Convert the instruction (if not already converted) and create a corresponding op-result value.
             ValueDef::Result(inst, idx) => {
                 let op = convert_instruction(ctx, dfg, cctx, inst)?;
                 let pliron_value = PlironValue::OpResult { op, res_idx: idx };
                 pliron_operands.push(pliron_value);
             }
-            // Is this value a BasicBlock parameter? If so, convert block parameter
+            // If the value is a block parameter:
+            // Convert the corresponding basic block and create a block argument value.
             ValueDef::Param(block, idx) => {
                 let block = convert_block(ctx, dfg, cctx, block)?;
                 let pliron_value = PlironValue::BlockArgument {
@@ -77,101 +85,116 @@ fn convert_operands(
     Ok(pliron_operands)
 }
 
-/// Converts a Cranelift [Inst] to Pliron's [Ptr<Operation>].
+/// Converts a Cranelift instruction ([Inst]) to a Pliron operation ([Ptr<Operation>]).
 ///
-/// This function checks if the instruction has already been converted (using `cctx` for caching).
-/// If not, it converts the instruction based on its opcode (like `Iadd` and `Return`).
+/// This function first checks whether the instruction has already been converted (caching is used).
+/// If not, it determines the opcode and converts the instruction accordingly.
+/// Supported opcodes include: Iadd, Umin, Umax, Ineg, Iabs, and Return.
 ///
 /// # Arguments
-/// - `ctx`: The Pliron context for creating IR entities.
-/// - `dfg`: The data flow graph containing the original instruction's information.
-/// - `cctx`: The conversion context for caching converted entities.
-/// - `inst`: The Cranelift `Inst` to convert.
+/// - `ctx`: The Pliron context for IR entity creation.
+/// - `dfg`: The Cranelift Data Flow Graph containing instruction definitions.
+/// - `cctx`: The conversion context for caching converted instructions.
+/// - `inst`: The Cranelift instruction to convert.
 ///
 /// # Returns
-/// A `Result` containing the converted `Operation` or an error if conversion fails.
+/// A Result containing a pointer to the converted [Operation] or an error if conversion fails.
 ///
 /// # Panics
-/// Panics if the opcode is not yet implemented
+/// Panics if an unsupported opcode is encountered.
 fn convert_instruction(
     ctx: &mut Context,
     dfg: &DataFlowGraph,
     cctx: &mut ConversionCtx,
     inst: Inst,
 ) -> Result<Ptr<Operation>> {
-    // Check if the instruction has already been converted
+    // If the instruction has already been converted, return the cached operation.
     if let Some(op) = cctx.ops.get(&inst) {
         return Ok(*op);
     };
 
-    // Convert the instruction based on its opcode
+    // Retrieve the opcode and arguments for the instruction.
     let clif_opcode = dfg.insts[inst].opcode();
     let inst_args = dfg.inst_args(inst);
     match clif_opcode {
+        // Handle integer addition.
         Opcode::Iadd => {
             let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
             let iadd_op = IAddOp::new(ctx, operands[0], operands[1]);
             let op = iadd_op.get_operation();
             return Ok(op);
         }
+        // Handle integer subtraction.
+        Opcode::Isub => {
+            let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
+            let isub_op = ISubOp::new(ctx, operands[0], operands[1]);
+            let op = isub_op.get_operation();
+            return Ok(op);
+        }
+        // Handle unsigned minimum.
         Opcode::Umin => {
             let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
             let umin_op = UminOp::new(ctx, operands[0], operands[1]);
             let op = umin_op.get_operation();
             return Ok(op);
         }
+        // Handle unsigned maximum.
         Opcode::Umax => {
             let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
             let umax_op = UmaxOp::new(ctx, operands[0], operands[1]);
             let op = umax_op.get_operation();
             return Ok(op);
         }
+        // Handle integer negation.
         Opcode::Ineg => {
             let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
             let ineg_op = InegOp::new(ctx, operands[0]);
             let op = ineg_op.get_operation();
             return Ok(op);
         }
+        // Handle integer absolute value.
         Opcode::Iabs => {
             let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
             let iabs_op = IabsOp::new(ctx, operands[0]);
             let op = iabs_op.get_operation();
             return Ok(op);
         }
+        // Handle return instructions.
         Opcode::Return => match inst_args.len() {
-            // No return values
+            // Return with no operands.
             0 => {
                 let return_op = ReturnOp::new(ctx, None);
                 let op = return_op.get_operation();
                 return Ok(op);
             }
-            // a single return value
+            // Return with a single operand.
             1 => {
                 let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
                 let return_op = ReturnOp::new(ctx, Some(operands[0]));
                 let op = return_op.get_operation();
                 return Ok(op);
             }
+            // Multiple return values are not supported.
             _ => unimplemented!("Multiple return values are not supported"),
         },
+        // For any unsupported opcode, panic with an error message.
         _ => unimplemented!("Opcode {} is not implemented", clif_opcode),
     }
 }
 
-/// Converts a [ClifBasicBlock] to Pliron's [BasicBlock].
+/// Converts a Cranelift basic block ([ClifBasicBlock]) to a Pliron basic block ([BasicBlock]).
 ///
-/// This function checks if the block has already been converted (using `cctx` for caching).
-/// If not, it creates a new `BasicBlock` in Pliron's IR, deriving its label and argument types
-/// from the provided `ClifBasicBlock`.
+/// This function checks the conversion cache; if the block is not yet converted, it creates a new
+/// Pliron basic block using a generated label and by converting the argument types of the block.
 ///
 /// # Arguments
-/// - `ctx`: The Pliron context for creating IR entities.
-/// - `dfg`: The data flow graph containing the original block's information.
-/// - `cctx`: The conversion context for caching converted entities.
-/// - `block`: The `ClifBasicBlock` to convert.
+/// - `ctx`: The Pliron context used for creating IR entities.
+/// - `dfg`: The Cranelift Data Flow Graph holding block parameter information.
+/// - `cctx`: The conversion context for caching converted basic blocks.
+/// - `block`: The Cranelift basic block to convert.
 ///
 /// # Returns
-/// A `Result` containing the converted `BasicBlock` or an error if conversion fails.
+/// A Result containing a pointer to the converted [BasicBlock] or an error if conversion fails.
 fn convert_block(
     ctx: &mut Context,
     dfg: &DataFlowGraph,
@@ -197,17 +220,16 @@ fn convert_block(
     Ok(pliron_block)
 }
 
-/// Converts a [ClifType] to Pliron's [TypeObj].
+/// Converts a Cranelift type ([ClifType]) to a Pliron type ([TypeObj]).
 ///
-/// This function maps Cranelift types to their corresponding Pliron types. Currently, only `i32`
-/// is supported.
-///
+/// This function currently supports conversion for `i32` only, mapping it to a 32-bit signed integer type.
+/// 
 /// # Arguments
-/// - `ctx`: The Pliron context for creating IR entities.
-/// - `ty`: The `ClifType` to convert.
+/// - `ctx`: The Pliron context used for creating type objects.
+/// - `ty`: The Cranelift type to convert.
 ///
 /// # Returns
-/// A `Result` containing the converted `TypeObj` or an error if conversion fails.
+/// A Result containing a pointer to the converted [TypeObj] or an error if conversion fails.
 ///
 /// # Panics
 /// Panics if the provided type is not yet implemented.
@@ -221,18 +243,18 @@ fn convert_type(ctx: &mut Context, ty: ClifType) -> Result<Ptr<TypeObj>> {
     }
 }
 
-/// Converts a Cranelift [Function] to a Pliron [FuncOp].
+/// Converts a Cranelift function ([Function]) to a Pliron function operation ([FuncOp]).
 ///
-/// This function translates all Cranelift entities (instructions, blocks, operands, types, etc.)
-/// into their Pliron equivalents and stores them in the conversion context (`cctx`).
+/// This function translates the function signature, entry block, and all blocks and instructions,
+/// storing converted entities in the conversion context for caching and linking.
 ///
 /// # Arguments
-/// - `ctx`: The Pliron context for creating IR entities.
-/// - `cctx`: The conversion context for caching converted entities.
-/// - `func`: The Cranelift `Function` to convert.
+/// - `ctx`: The Pliron context used for IR creation.
+/// - `cctx`: The conversion context used to cache converted entities.
+/// - `func`: The Cranelift function to convert.
 ///
 /// # Returns
-/// A `Result` containing the converted `FuncOp` or an error if conversion fails.
+/// A Result containing the converted [FuncOp] or an error if conversion fails.
 ///
 /// # Panics
 /// Panics if the function's entry block or types cannot be converted.
@@ -323,6 +345,18 @@ fn convert_function(ctx: &mut Context, cctx: &mut ConversionCtx, func: Function)
     Ok(func_op)
 }
 
+/// Converts operands in reverse postorder (RPO).
+///
+/// With RPO, we assume that any operand's definition has already been converted,
+/// so we can safely unwrap conversion results.
+///
+/// # Arguments
+/// - `dfg`: The Cranelift data flow graph.
+/// - `cctx`: The conversion context caching converted entities.
+/// - `operands`: The slice of Cranelift values to convert.
+///
+/// # Returns
+/// A Result containing a vector of converted Pliron values.
 fn convert_operands_w_rpo(
     dfg: &DataFlowGraph,
     cctx: &mut ConversionCtx,
@@ -362,6 +396,19 @@ fn convert_operands_w_rpo(
     Ok(pliron_operands)
 }
 
+/// Converts a Cranelift instruction ([Inst]) to a Pliron operation using RPO assumptions.
+///
+/// This version of conversion assumes that operand definitions have already been converted,
+/// allowing safe unwrapping when retrieving operands.
+///
+/// # Arguments
+/// - `ctx`: The Pliron context for IR creation.
+/// - `dfg`: The Cranelift data flow graph.
+/// - `cctx`: The conversion context caching converted entities.
+/// - `inst`: The Cranelift instruction to convert.
+///
+/// # Returns
+/// A Result containing a pointer to the converted [Operation].
 fn convert_instruction_w_rpo(
     ctx: &mut Context,
     dfg: &DataFlowGraph,
@@ -378,6 +425,13 @@ fn convert_instruction_w_rpo(
             let op = iadd_op.get_operation();
             return Ok(op);
         }
+        Opcode::Isub => {
+            let operands = convert_operands(ctx, dfg, cctx, &inst_args)?;
+            let isub_op = ISubOp::new(ctx, operands[0], operands[1]);
+            let op = isub_op.get_operation();
+            return Ok(op);
+        }
+
         Opcode::Return => match inst_args.len() {
             // No return values
             0 => {
@@ -398,6 +452,18 @@ fn convert_instruction_w_rpo(
     }
 }
 
+/// Converts a Cranelift basic block to a Pliron basic block using RPO conversion.
+///
+/// This version does not use the conversion cache since RPO ordering ensures that operands are already
+/// converted in the proper order.
+///
+/// # Arguments
+/// - `ctx`: The Pliron context for IR creation.
+/// - `dfg`: The Cranelift data flow graph.
+/// - `block`: The Cranelift basic block to convert.
+///
+/// # Returns
+/// A Result containing a pointer to the converted [BasicBlock].
 fn convert_block_w_rpo(
     ctx: &mut Context,
     dfg: &DataFlowGraph,
@@ -417,6 +483,18 @@ fn convert_block_w_rpo(
     Ok(pliron_block)
 }
 
+/// Converts a Cranelift function to a Pliron function operation using Reverse Postorder (RPO).
+///
+/// This function is similar to `convert_function` but leverages RPO ordering,
+/// which guarantees that definitions are processed before their uses.
+///
+/// # Arguments
+/// - `ctx`: The Pliron context for IR creation.
+/// - `cctx`: The conversion context caching converted entities.
+/// - `func`: The Cranelift function to convert.
+///
+/// # Returns
+/// A Result containing the converted [FuncOp] or an error if conversion fails.
 fn convert_function_w_rpo(
     ctx: &mut Context,
     cctx: &mut ConversionCtx,
@@ -493,7 +571,9 @@ fn convert_function_w_rpo(
     // Create the Pliron `FuncOp`
     let func_op = FuncOp::new(ctx, &Identifier::try_new(func_name)?, pliron_func_type);
 
-    // Update the conversion context
+    // Update the conversion context:
+    // Map the Cranelift entry block to the Pliron entry block,
+    // store the function's region and the function op.
     let pliron_entry_blk = func_op.get_entry_block(ctx);
     if let Some(blk) = func.layout.entry_block() {
         cctx.bbs.insert(blk, pliron_entry_blk);
@@ -511,15 +591,15 @@ fn convert_function_w_rpo(
 }
 /// Tracks converted Pliron entities during IR transformation.
 ///
-/// This struct ensures efficient lookup and prevents redundant conversions of operations,
-/// regions, and basic blocks during the transformation process.
+/// This structure caches converted operations, regions, and basic blocks,
+/// ensuring efficient lookups and preventing redundant conversions.
 ///
 /// # Fields
-/// - `ops`: Maps original instructions to their converted `Operation` entities.
-/// - `regs`: Stores pointers to converted `Region` entities.
-/// - `bbs`: Maps `ClifBasicBlock`s to their corresponding Pliron `BasicBlock`s.
-/// - `entry_block`: The entry `BasicBlock` of the function being processed, if any.
-/// - `func_op`: The root `Operation` representing the function being processed, if any.
+/// - `ops`: Maps Cranelift instructions (Inst) to their corresponding Pliron [Operation] pointers.
+/// - `regs`: Stores pointers to converted [Region] entities.
+/// - `bbs`: Maps Cranelift basic blocks to their corresponding Pliron [BasicBlock] pointers.
+/// - `entry_block`: The entry [BasicBlock] of the function being processed.
+/// - `func_op`: The root [Operation] representing the function being processed.
 #[derive(Default)]
 struct ConversionCtx {
     ops: FxHashMap<Inst, Ptr<Operation>>,
@@ -531,10 +611,12 @@ struct ConversionCtx {
 
 #[cfg(test)]
 mod tests {
+    // Import required items for testing.
     use super::*;
     use cranelift_reader::parse_functions;
     use pliron::{builtin, printable::Printable};
 
+    /// Test converting a Cranelift function that adds two i32 values to a Pliron function.
     #[test]
     fn test_add_fn_convert_clif_to_pliron() {
         let clif_code = r#"
@@ -545,19 +627,25 @@ mod tests {
         }
     "#;
 
+        // Parse the CLIF code to obtain Cranelift functions.
         let functions = parse_functions(clif_code).expect("Failed to parse .clif");
 
+        // Process each function.
         for func in functions {
             let mut cctx = ConversionCtx::default();
             let mut ctx = Context::new();
+            // Register built-in and custom dialects/ops.
             builtin::register(&mut ctx);
             crate::register(&mut ctx);
+            // Convert the Cranelift function to a Pliron function.
             let func_op = match convert_function(&mut ctx, &mut cctx, func) {
                 Ok(op) => op,
                 Err(e) => panic!("Error: {}", e),
             };
+            // Print the resulting function.
             let print_func = func_op.disp(&ctx);
             println!("{}", print_func);
+            // Assert that the printed function matches the expected output.
             assert_eq!(
                             "builtin.func @add: builtin.function <(builtin.int <si32>, builtin.int <si32>)->(builtin.int <si32>)> 
 {
@@ -570,6 +658,7 @@ mod tests {
         }
     }
 
+    /// Test converting a Cranelift function to Pliron using RPO ordering.
     #[test]
     fn test_add_fn_convert_clif_to_pliron_w_rpo() {
         let clif_code = r#"
@@ -603,6 +692,7 @@ mod tests {
         }
     }
 
+    /// Test converting a Cranelift function that implements unsigned minimum (umin) to Pliron.
     #[test]
     fn test_umin_fn_convert_clif_to_pliron() {
         let clif_code = r#"
@@ -638,6 +728,7 @@ mod tests {
         }
     }
 
+    /// Test converting a Cranelift function that implements integer negation (ineg) to Pliron.
     #[test]
     fn test_ineg_fn_convert_clif_to_pliron() {
         let clif_code = r#"
@@ -673,6 +764,7 @@ mod tests {
         }
     }
 
+    /// Test converting a Cranelift function that implements unsigned maximum (umax) to Pliron.
     #[test]
     fn test_umax_fn_convert_clif_to_pliron() {
         let clif_code = r#"
@@ -707,4 +799,75 @@ mod tests {
         );
         }
     }
+
+     /// Test converting a Cranelift function that implements integer subtraction (isub) to Pliron.
+     #[test]
+     fn test_sub_fn_convert_clif_to_pliron() {
+         let clif_code = r#"
+         function %sub(i32, i32) -> i32 apple_aarch64 {
+             block0(v0: i32, v1: i32):
+                 v2 = isub v0, v1
+                 return v2
+         }
+     "#;
+ 
+         let functions = parse_functions(clif_code).expect("Failed to parse .clif");
+ 
+         for func in functions {
+             let mut cctx = ConversionCtx::default();
+             let mut ctx = Context::new();
+             builtin::register(&mut ctx);
+             crate::register(&mut ctx);
+             let func_op = match convert_function(&mut ctx, &mut cctx, func) {
+                 Ok(op) => op,
+                 Err(e) => panic!("Error: {}", e),
+             };
+             let print_func = func_op.disp(&ctx);
+             println!("{}", print_func);
+             assert_eq!(
+                 "builtin.func @sub: builtin.function <(builtin.int <si32>, builtin.int <si32>)->(builtin.int <si32>)> \n{\
+ \n  ^entry_block_1v1(block_1v1_arg0:builtin.int <si32>,block_1v1_arg1:builtin.int <si32>):\
+ \n    op_2v1_res0 = clif.isub block_1v1_arg0,block_1v1_arg1:builtin.int <si32>;\
+ \n    clif.return (op_2v1_res0)\
+ \n}",
+                 format!("{}", print_func)
+             );
+         }
+     }
+ 
+     /// Test converting a Cranelift function that implements integer absolute value (iabs) to Pliron.
+     #[test]
+     fn test_abs_fn_convert_clif_to_pliron() {
+         let clif_code = r#"
+         function %abs(i32) -> i32 apple_aarch64 {
+             block0(v0: i32):
+                 v1 = iabs v0
+                 return v1
+         }
+     "#;
+ 
+         let functions = parse_functions(clif_code).expect("Failed to parse .clif");
+ 
+         for func in functions {
+             let mut cctx = ConversionCtx::default();
+             let mut ctx = Context::new();
+             builtin::register(&mut ctx);
+             crate::register(&mut ctx);
+             let func_op = match convert_function(&mut ctx, &mut cctx, func) {
+                 Ok(op) => op,
+                 Err(e) => panic!("Error: {}", e),
+             };
+             let print_func = func_op.disp(&ctx);
+             println!("{}", print_func);
+             assert_eq!(
+                 "builtin.func @abs: builtin.function <(builtin.int <si32>)->(builtin.int <si32>)> \n{\
+ \n  ^entry_block_1v1(block_1v1_arg0:builtin.int <si32>):\
+ \n    op_2v1_res0 = clif.iabs block_1v1_arg0;\
+ \n    clif.return (op_2v1_res0)\
+ \n}",
+                 format!("{}", print_func)
+             );
+         }
+     }
+ 
 }

--- a/pliron-clif/src/lib.rs
+++ b/pliron-clif/src/lib.rs
@@ -1,15 +1,39 @@
+// Import required types from the Pliron framework:
+// - `Context`: The IR context in which dialects and ops are registered.
+// - `Dialect` and `DialectName`: Used to define and name new dialects.
 use pliron::{
     context::Context,
     dialect::{Dialect, DialectName},
 };
 
+// Declare sub-modules for this dialect:
+// - `attributes`: Contains attribute definitions for the dialect.
+// - `from_clif_ir`: Provides functionality to convert from CLIF IR to Pliron IR.
+// - `op_interfaces`: Defines interfaces for operations (ops) in this dialect.
+// - `ops`: Implements the actual operations.
 pub mod attributes;
 pub mod from_clif_ir;
 pub mod op_interfaces;
 pub mod ops;
 
+/// Registers the CLIF dialect and its associated operations into the provided context.
+///
+/// # Arguments
+///
+/// * `ctx` - A mutable reference to the current IR context.
+///
+/// # Process
+///
+/// 1. Creates a new dialect named "clif" using the `DialectName::new` constructor.
+/// 2. Registers the newly created dialect with the context so that it can be recognized.
+/// 3. Calls the registration function in the `ops` module to register all CLIF operations.
+///
+/// This setup is essential for enabling the use and parsing of CLIF-based operations in the IR.
 pub fn register(ctx: &mut Context) {
+    // Create a new dialect with the name "clif"
     let dialect = Dialect::new(DialectName::new("clif"));
+    // Register the dialect into the given context
     dialect.register(ctx);
+    // Register all operations defined in the `ops` module into the context
     ops::register(ctx);
 }

--- a/pliron-clif/src/op_interfaces.rs
+++ b/pliron-clif/src/op_interfaces.rs
@@ -1,4 +1,7 @@
-use pliron::{builtin::op_interfaces::{SameOperandsType, SameResultsType}, derive::op_interface};
+use pliron::{
+    builtin::op_interfaces::{SameOperandsType, SameResultsType},
+    derive::op_interface,
+};
 use thiserror::Error;
 
 use pliron::{
@@ -73,10 +76,7 @@ pub trait UnaryArithOp: SameOperandsType + SameResultsType + OneResultInterface 
             vec![],
             0,
         );
-        *Operation::get_op(op, ctx)
-            .downcast::<Self>()
-            .ok()
-            .unwrap()
+        *Operation::get_op(op, ctx).downcast::<Self>().ok().unwrap()
     }
 
     /// Verify that the operation has exactly one operand.
@@ -118,8 +118,6 @@ pub trait IntUnaryArithOp: UnaryArithOp {
         Ok(())
     }
 }
-
-
 
 #[derive(Error, Debug)]
 #[error("Integer binary arithmetic Op can only have signless integer result/operand type")]

--- a/pliron-clif/src/op_interfaces.rs
+++ b/pliron-clif/src/op_interfaces.rs
@@ -1,10 +1,15 @@
+// Import required traits and macros from the Pliron framework.
+// - `SameOperandsType` and `SameResultsType` ensure that the operation’s operands/results are of the same type.
+// - `op_interface` is a macro to derive op interface implementations.
 use pliron::{
     builtin::op_interfaces::{SameOperandsType, SameResultsType},
     derive::op_interface,
 };
+// Import the `Error` derive macro from the thiserror crate.
 use thiserror::Error;
 
 use pliron::{
+     // Import additional op interfaces and types needed for binary/unary arithmetic operations.
     builtin::{
         op_interfaces::{OneResultInterface, SameOperandsAndResultType},
         types::{IntegerType, Signedness},
@@ -20,18 +25,56 @@ use pliron::{
     verify_err,
 };
 
+/// -------------------------------------------------------------------------
+/// Error Types for Arithmetic Operations
+/// -------------------------------------------------------------------------
 #[derive(Error, Debug)]
 #[error("Binary Arithmetic Op must have exactly two operands and one result")]
 pub struct BinArithOpErr;
 
-/// Binary arithmetic [Op].
+/// Error for unary arithmetic operations if they do not have exactly one operand and one result.
+#[derive(Error, Debug)]
+#[error("Unary Arithmetic Op must have exactly one operand and one result")]
+pub struct UnaryArithOpErr;
+
+/// Error for integer unary arithmetic operations if the result/operand type is not a signless integer.
+#[derive(Error, Debug)]
+#[error("Integer unary arithmetic Op can only have signless integer result/operand type")]
+pub struct IntUnaryArithOpErr;
+
+/// Error for integer binary arithmetic operations if the result/operand type is not a signless integer.
+#[derive(Error, Debug)]
+#[error("Integer binary arithmetic Op can only have signless integer result/operand type")]
+pub struct IntBinArithOpErr;
+
+/// -------------------------------------------------------------------------
+/// Binary Arithmetic Operation Trait
+/// -------------------------------------------------------------------------
+
+/// Trait for binary arithmetic operations.
+///
+/// This trait extends `SameOperandsAndResultType` and `OneResultInterface` to ensure that
+/// binary operations have two operands with the same type and one result with that type.
+/// It also provides a helper method `new` to create a new binary op and a `verify` method to
+/// ensure the op has exactly two operands.
 #[op_interface]
 pub trait BinArithOp: SameOperandsAndResultType + OneResultInterface {
-    /// Create a new binary arithmetic operation given the operands.
+    /// Create a new binary arithmetic operation given two operands.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The context in which the op is created.
+    /// * `lhs` - The left-hand side operand.
+    /// * `rhs` - The right-hand side operand.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of the binary arithmetic operation.
     fn new(ctx: &mut Context, lhs: Value, rhs: Value) -> Self
     where
         Self: Sized,
     {
+        // Create a new operation with the type of the left-hand side
         let op = Operation::new(
             ctx,
             Self::get_opid_static(),
@@ -40,14 +83,27 @@ pub trait BinArithOp: SameOperandsAndResultType + OneResultInterface {
             vec![],
             0,
         );
+        // Downcast the generic operation to the specific operation type.
         *Operation::get_op(op, ctx).downcast::<Self>().ok().unwrap()
     }
 
+    /// Verify that the operation has exactly two operands.
+    ///
+    /// # Arguments
+    ///
+    /// * `op` - The operation to verify.
+    /// * `ctx` - The context for type and operand resolution.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if verification succeeds, or an error wrapped in a `Result` otherwise.
     fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
     where
         Self: Sized,
     {
+        // Get the underlying operation using the context.
         let op = op.get_operation().deref(ctx);
+        // Check if the number of operands is exactly 2.
         if op.get_num_operands() != 2 {
             return verify_err!(op.loc(), BinArithOpErr);
         }
@@ -56,18 +112,34 @@ pub trait BinArithOp: SameOperandsAndResultType + OneResultInterface {
     }
 }
 
-#[derive(Error, Debug)]
-#[error("Unary Arithmetic Op must have exactly one operand and one result")]
-pub struct UnaryArithOpErr;
 
-/// Unary arithmetic [Op].
+
+/// -------------------------------------------------------------------------
+/// Unary Arithmetic Operation Trait
+/// -------------------------------------------------------------------------
+
+/// Trait for unary arithmetic operations.
+///
+/// This trait extends `SameOperandsType`, `SameResultsType`, and `OneResultInterface` to ensure that
+/// unary operations have one operand and one result of the same type. It provides a helper method `new`
+/// for creation and a `verify` method to enforce the operand count.
 #[op_interface]
 pub trait UnaryArithOp: SameOperandsType + SameResultsType + OneResultInterface {
-    /// Create a new unary arithmetic operation given the operand.
+     /// Create a new unary arithmetic operation given a single operand.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The context in which the op is created.
+    /// * `x` - The operand.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of the unary arithmetic operation.
     fn new(ctx: &mut Context, x: Value) -> Self
     where
         Self: Sized,
     {
+        // Create a new operation with the type of the operand.
         let op = Operation::new(
             ctx,
             Self::get_opid_static(),
@@ -76,15 +148,26 @@ pub trait UnaryArithOp: SameOperandsType + SameResultsType + OneResultInterface 
             vec![],
             0,
         );
+        // Downcast the generic operation to the specific operation type.
         *Operation::get_op(op, ctx).downcast::<Self>().ok().unwrap()
     }
 
     /// Verify that the operation has exactly one operand.
+    ///
+    /// # Arguments
+    ///
+    /// * `op` - The operation to verify.
+    /// * `ctx` - The context for type and operand resolution.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if verification succeeds, or an error wrapped in a `Result` otherwise.
     fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
     where
         Self: Sized,
     {
         let op = op.get_operation().deref(ctx);
+        // Check if the number of operands is exactly 1.
         if op.get_num_operands() != 1 {
             return verify_err!(op.loc(), UnaryArithOpErr);
         }
@@ -92,25 +175,41 @@ pub trait UnaryArithOp: SameOperandsType + SameResultsType + OneResultInterface 
     }
 }
 
-#[derive(Error, Debug)]
-#[error("Integer unary arithmetic Op can only have signless integer result/operand type")]
-pub struct IntUnaryArithOpErr;
+/// -------------------------------------------------------------------------
+/// Integer Unary Arithmetic Operation Trait
+/// -------------------------------------------------------------------------
 
-/// Integer unary arithmetic [Op].
+/// Trait for integer unary arithmetic operations.
+///
+/// This trait extends `UnaryArithOp` and adds additional verification to ensure that
+/// the operand and result types are signless integers.
 #[op_interface]
 pub trait IntUnaryArithOp: UnaryArithOp {
+     /// Verify that the operand and result types are signless integers.
+    ///
+    /// # Arguments
+    ///
+    /// * `op` - The operation to verify.
+    /// * `ctx` - The context for type and operand resolution.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if verification succeeds, or an error wrapped in a `Result` otherwise.
     fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
     where
         Self: Sized,
     {
+        // Get the type of the op (from the trait ensuring operands and results have the same type).
         let ty = op_cast::<dyn SameOperandsAndResultType>(op)
             .expect("Op must implement SameOperandsAndResultType")
             .get_type(ctx)
             .deref(ctx);
+        // Attempt to downcast the type to an IntegerType.
         let Some(int_ty) = ty.downcast_ref::<IntegerType>() else {
             return verify_err!(op.get_operation().deref(ctx).loc(), IntUnaryArithOpErr);
         };
 
+        // Check that the integer type is signless.
         if int_ty.get_signedness() != Signedness::Signless {
             return verify_err!(op.get_operation().deref(ctx).loc(), IntUnaryArithOpErr);
         }
@@ -119,25 +218,43 @@ pub trait IntUnaryArithOp: UnaryArithOp {
     }
 }
 
-#[derive(Error, Debug)]
-#[error("Integer binary arithmetic Op can only have signless integer result/operand type")]
-pub struct IntBinArithOpErr;
+
  
-/// Integer binary arithmetic [Op]
+/// -------------------------------------------------------------------------
+/// Integer Binary Arithmetic Operation Trait
+/// -------------------------------------------------------------------------
+
+/// Trait for integer binary arithmetic operations.
+///
+/// This trait extends `BinArithOp` and adds additional verification to ensure that
+/// the operand and result types are signless integers.
 #[op_interface]
 pub trait IntBinArithOp: BinArithOp {
+    /// Verify that the operand and result types are signless integers.
+    ///
+    /// # Arguments
+    ///
+    /// * `op` - The operation to verify.
+    /// * `ctx` - The context for type and operand resolution.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if verification succeeds, or an error wrapped in a `Result` otherwise.
     fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
     where
         Self: Sized,
     {
+        // Get the type of the op from the trait ensuring operands and results are the same.
         let ty = op_cast::<dyn SameOperandsAndResultType>(op)
             .expect("Op must impl SameOperandsAndResultType")
             .get_type(ctx)
             .deref(ctx);
+        // Attempt to downcast the type to an IntegerType.
         let Some(int_ty) = ty.downcast_ref::<IntegerType>() else {
             return verify_err!(op.get_operation().deref(ctx).loc(), IntBinArithOpErr);
         };
 
+        // Check that the integer type is signless.
         if int_ty.get_signedness() != Signedness::Signless {
             return verify_err!(op.get_operation().deref(ctx).loc(), IntBinArithOpErr);
         }

--- a/pliron-clif/src/op_interfaces.rs
+++ b/pliron-clif/src/op_interfaces.rs
@@ -1,4 +1,4 @@
-use pliron::derive::op_interface;
+use pliron::{builtin::op_interfaces::{SameOperandsType, SameResultsType}, derive::op_interface};
 use thiserror::Error;
 
 use pliron::{
@@ -52,6 +52,74 @@ pub trait BinArithOp: SameOperandsAndResultType + OneResultInterface {
         Ok(())
     }
 }
+
+#[derive(Error, Debug)]
+#[error("Unary Arithmetic Op must have exactly one operand and one result")]
+pub struct UnaryArithOpErr;
+
+/// Unary arithmetic [Op].
+#[op_interface]
+pub trait UnaryArithOp: SameOperandsType + SameResultsType + OneResultInterface {
+    /// Create a new unary arithmetic operation given the operand.
+    fn new(ctx: &mut Context, x: Value) -> Self
+    where
+        Self: Sized,
+    {
+        let op = Operation::new(
+            ctx,
+            Self::get_opid_static(),
+            vec![x.get_type(ctx)],
+            vec![x],
+            vec![],
+            0,
+        );
+        *Operation::get_op(op, ctx)
+            .downcast::<Self>()
+            .ok()
+            .unwrap()
+    }
+
+    /// Verify that the operation has exactly one operand.
+    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let op = op.get_operation().deref(ctx);
+        if op.get_num_operands() != 1 {
+            return verify_err!(op.loc(), UnaryArithOpErr);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("Integer unary arithmetic Op can only have signless integer result/operand type")]
+pub struct IntUnaryArithOpErr;
+
+/// Integer unary arithmetic [Op].
+#[op_interface]
+pub trait IntUnaryArithOp: UnaryArithOp {
+    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let ty = op_cast::<dyn SameOperandsAndResultType>(op)
+            .expect("Op must implement SameOperandsAndResultType")
+            .get_type(ctx)
+            .deref(ctx);
+        let Some(int_ty) = ty.downcast_ref::<IntegerType>() else {
+            return verify_err!(op.get_operation().deref(ctx).loc(), IntUnaryArithOpErr);
+        };
+
+        if int_ty.get_signedness() != Signedness::Signless {
+            return verify_err!(op.get_operation().deref(ctx).loc(), IntUnaryArithOpErr);
+        }
+
+        Ok(())
+    }
+}
+
+
 
 #[derive(Error, Debug)]
 #[error("Integer binary arithmetic Op can only have signless integer result/operand type")]

--- a/pliron-clif/src/op_interfaces.rs
+++ b/pliron-clif/src/op_interfaces.rs
@@ -122,7 +122,7 @@ pub trait IntUnaryArithOp: UnaryArithOp {
 #[derive(Error, Debug)]
 #[error("Integer binary arithmetic Op can only have signless integer result/operand type")]
 pub struct IntBinArithOpErr;
-
+ 
 /// Integer binary arithmetic [Op]
 #[op_interface]
 pub trait IntBinArithOp: BinArithOp {

--- a/pliron-clif/src/ops.rs
+++ b/pliron-clif/src/ops.rs
@@ -1,4 +1,7 @@
-//! [Op]s defined in the CLIF dialect
+//! [Op]s defined in the CLIF dialect.
+//! 
+//! This module defines a set of operations (ops) that mirror the CLIF dialect using the Pliron framework.
+//! It includes both binary and unary arithmetic operations along with a return operation.
 
 use pliron::derive::{def_op, derive_op_interface_impl};
 
@@ -18,19 +21,31 @@ use pliron::{
 
 use crate::op_interfaces::{BinArithOp, IntBinArithOp, IntUnaryArithOp, UnaryArithOp};
 
-/// Equivalent to CLIF's return opcode.
+/// -------------------------------------------------------------------------
+/// ReturnOp
+/// -------------------------------------------------------------------------
 ///
-/// Operands:
+/// This op is equivalent to CLIF's `return` opcode. It takes an optional value
+/// (of any type) as an operand and returns it. When no operand is provided,
+/// it represents a void return.
 ///
-/// | Operand | Description |
-/// |---------|-------------|
-/// | `arg`   | any type    |
+/// **Operands:**
+/// - `arg`: any type
 #[def_op("clif.return")]
 #[format_op("`(` operands(CharSpace(`,`)) `)`")]
 #[derive_op_interface_impl(IsTerminatorInterface)]
 pub struct ReturnOp;
 impl ReturnOp {
-    /// Create a new [ReturnOp]
+    /// Creates a new ReturnOp.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The current context in which the op is created.
+    /// * `value` - An optional value to return.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of ReturnOp.
     pub fn new(ctx: &mut Context, value: Option<Value>) -> Self {
         let op = Operation::new(
             ctx,
@@ -43,7 +58,16 @@ impl ReturnOp {
         ReturnOp { op }
     }
 
-    /// Get the returned value, if it exists.
+    /// Retrieves the return value from the op if one exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The current context.
+    ///
+    /// # Returns
+    ///
+    /// * `Some(Value)` if there is exactly one operand,
+    /// * `None` otherwise.
     pub fn retval(&self, ctx: &Context) -> Option<Value> {
         let op = &*self.get_operation().deref(ctx);
         if op.get_num_operands() == 1 {
@@ -56,6 +80,16 @@ impl ReturnOp {
 // impl_canonical_syntax!(ReturnOp);
 impl_verify_succ!(ReturnOp);
 
+/// -------------------------------------------------------------------------
+/// Macros for Defining Integer Binary Operations
+/// -------------------------------------------------------------------------
+
+/// Macro to define a binary op for integer arithmetic without a custom formatting string.
+/// It sets up the op with its operand and result interfaces.
+/// 
+/// Parameters:
+/// - `$op_name`: Identifier for the op struct.
+/// - `$op_id`: The string identifier for the op (e.g., "clif.iadd").
 macro_rules! new_int_bin_op_without_format {
     (   $(#[$outer:meta])*
         $op_name:ident, $op_id:literal
@@ -70,7 +104,6 @@ macro_rules! new_int_bin_op_without_format {
         /// | `rhs`   | Signless integer |
         ///
         /// ### Result(s):
-        ///{}
         /// | result | description      |
         /// |--------|------------------|
         /// | `res`  | Signless integer |
@@ -84,6 +117,11 @@ macro_rules! new_int_bin_op_without_format {
     }
 }
 
+/// Macro to define a binary op for integer arithmetic with a specific formatting string.
+/// It builds on `new_int_bin_op_without_format!` while adding a format specification.
+///
+/// The provided format string prints the first operand, a literal comma, the second operand,
+/// and appends a colon with the type of the first operand.
 macro_rules! new_int_bin_op {
     (   $(#[$outer:meta])*
         $op_name:ident, $op_id:literal
@@ -97,6 +135,16 @@ macro_rules! new_int_bin_op {
     }
 }
 
+/// -------------------------------------------------------------------------
+/// Macros for Defining Integer Unary Operations
+/// -------------------------------------------------------------------------
+
+/// Macro to define a unary op for integer arithmetic without a custom formatting string.
+/// It sets up the op with its operand and result interfaces.
+///
+/// Parameters:
+/// - `$op_name`: Identifier for the op struct.
+/// - `$op_id`: The string identifier for the op (e.g., "clif.ineg").
 macro_rules! new_int_unary_op_without_format {
     (   $(#[$outer:meta])*
         $op_name:ident, $op_id:literal
@@ -123,6 +171,10 @@ macro_rules! new_int_unary_op_without_format {
     }
 }
 
+/// Macro to define a unary op for integer arithmetic with a specific formatting string.
+/// It builds on `new_int_unary_op_without_format!` while adding a format specification.
+///
+/// The format string prints the operand, followed by a colon and its type.
 macro_rules! new_int_unary_op {
     (   $(#[$outer:meta])*
         $op_name:ident, $op_id:literal
@@ -136,11 +188,14 @@ macro_rules! new_int_unary_op {
     }
 }
 
+// Define the integer addition op (`clif.iadd`).
 new_int_bin_op!(
     /// Equivalent to CLIF's standard integer addition (with no overflow) opcode.
     IAddOp,
     "clif.iadd"
 );
+
+// Define the integer subtraction op (`clif.isub`).
 
 new_int_bin_op!(
     /// Equivalent to CLIF's standard integer subtraction (with no overflow) opcode.
@@ -148,17 +203,21 @@ new_int_bin_op!(
     "clif.isub"
 );
 
+// Define the unsigned minimum op (`clif.umin`).
 new_int_bin_op!(
     /// Equivalent to CLIF's standard integer subtraction (with no overflow) opcode.
     UminOp,
     "clif.umin"
 );
 
+// Define the unsigned maximum op (`clif.umax`).
 new_int_bin_op!(
     /// Equivalent to CLIF's standard integer subtraction (with no overflow) opcode.
     UmaxOp,
     "clif.umax"
 );
+
+// Define the integer negation op (`clif.ineg`).
 
 new_int_unary_op!(
     /// Equivalent to CLIF's integer negation (`ineg`) opcode.
@@ -166,12 +225,19 @@ new_int_unary_op!(
     "clif.ineg"
 );
 
+// Define the integer absolute value op (`clif.iabs`).
 new_int_unary_op!(
     /// Equivalent to CLIF's integer negation (`ineg`) opcode.
     IabsOp,
     "clif.iabs"
 );
 
+/// -------------------------------------------------------------------------
+/// Registration Function
+/// -------------------------------------------------------------------------
+///
+/// This function registers all the defined ops into the given context.
+/// It ensures that each op is available for parsing and conversion.
 pub fn register(ctx: &mut Context) {
     ReturnOp::register(ctx, ReturnOp::parser_fn);
     IAddOp::register(ctx, IAddOp::parser_fn);

--- a/pliron-clif/src/ops.rs
+++ b/pliron-clif/src/ops.rs
@@ -129,7 +129,7 @@ macro_rules! new_int_unary_op {
     ) => {
         new_int_unary_op_without_format!(
             $(#[$outer])*
-            #[format_op("`$0` : type($0)")]
+            #[format_op("$0':'type($0)")]
             $op_name,
             $op_id
         );

--- a/pliron-clif/src/ops.rs
+++ b/pliron-clif/src/ops.rs
@@ -16,7 +16,7 @@ use pliron::{
     value::Value,
 };
 
-use crate::op_interfaces::{BinArithOp, IntBinArithOp};
+use crate::op_interfaces::{BinArithOp, IntBinArithOp, UnaryArithOp, IntUnaryArithOp};
 
 /// Equivalent to CLIF's return opcode.
 ///
@@ -97,6 +97,45 @@ macro_rules! new_int_bin_op {
     }
 }
 
+macro_rules! new_int_unary_op_without_format {
+    (   $(#[$outer:meta])*
+        $op_name:ident, $op_id:literal
+    ) => {
+        #[def_op($op_id)]
+        $(#[$outer])*
+        /// ### Operand:
+        ///
+        /// | operand | description      |
+        /// |---------|------------------|
+        /// | `x`     | Signless integer |
+        ///
+        /// ### Result:
+        /// | result | description      |
+        /// |--------|------------------|
+        /// | `res`  | Signless integer |
+        #[pliron::derive::derive_op_interface_impl(
+            OneResultInterface, SameOperandsType, SameResultsType,
+            UnaryArithOp, IntUnaryArithOp
+        )]
+        pub struct $op_name;
+
+        impl_verify_succ!($op_name);
+    }
+}
+
+macro_rules! new_int_unary_op {
+    (   $(#[$outer:meta])*
+        $op_name:ident, $op_id:literal
+    ) => {
+        new_int_unary_op_without_format!(
+            $(#[$outer])*
+            #[format_op("`$0` : type($0)")]
+            $op_name,
+            $op_id
+        );
+    }
+}
+
 new_int_bin_op!(
     /// Equivalent to CLIF's standard integer addition (with no overflow) opcode.
     IAddOp,
@@ -109,8 +148,37 @@ new_int_bin_op!(
     "clif.isub"
 );
 
+new_int_bin_op!(
+    /// Equivalent to CLIF's standard integer subtraction (with no overflow) opcode.
+    UminOp,
+    "clif.umin"
+);
+
+new_int_bin_op!(
+    /// Equivalent to CLIF's standard integer subtraction (with no overflow) opcode.
+    UmaxOp,
+    "clif.umax"
+);
+
+new_int_unary_op!(
+    /// Equivalent to CLIF's integer negation (`ineg`) opcode.
+    InegOp,
+    "clif.ineg"
+);
+
+new_int_unary_op!(
+    /// Equivalent to CLIF's integer negation (`ineg`) opcode.
+    IabsOp,
+    "clif.iabs"
+);
+
+
 pub fn register(ctx: &mut Context) {
     ReturnOp::register(ctx, ReturnOp::parser_fn);
     IAddOp::register(ctx, IAddOp::parser_fn);
     ISubOp::register(ctx, ISubOp::parser_fn);
+    UminOp::register(ctx, UminOp::parser_fn);
+    UmaxOp::register(ctx, UmaxOp::parser_fn);
+    InegOp::register(ctx, InegOp::parser_fn);
+    IabsOp::register(ctx, IabsOp::parser_fn);
 }

--- a/pliron-clif/src/ops.rs
+++ b/pliron-clif/src/ops.rs
@@ -16,7 +16,7 @@ use pliron::{
     value::Value,
 };
 
-use crate::op_interfaces::{BinArithOp, IntBinArithOp, UnaryArithOp, IntUnaryArithOp};
+use crate::op_interfaces::{BinArithOp, IntBinArithOp, IntUnaryArithOp, UnaryArithOp};
 
 /// Equivalent to CLIF's return opcode.
 ///
@@ -171,7 +171,6 @@ new_int_unary_op!(
     IabsOp,
     "clif.iabs"
 );
-
 
 pub fn register(ctx: &mut Context) {
     ReturnOp::register(ctx, ReturnOp::parser_fn);

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -61,7 +61,7 @@ use super::{
 /// |-----|-------|
 /// | `arg` | any type |
 #[def_op("llvm.return")]
-#[derive_op_interface_impl(IsTerminatorInterface)]
+#[derive_op_interface_impl(IsTerminatorInterface)] 
 pub struct ReturnOp;
 impl ReturnOp {
     /// Create a new [ReturnOp]

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -61,7 +61,7 @@ use super::{
 /// |-----|-------|
 /// | `arg` | any type |
 #[def_op("llvm.return")]
-#[derive_op_interface_impl(IsTerminatorInterface)] 
+#[derive_op_interface_impl(IsTerminatorInterface)]
 pub struct ReturnOp;
 impl ReturnOp {
     /// Create a new [ReturnOp]


### PR DESCRIPTION
- Implemented conversion support for all key opcodes: IAdd, ISub, Umin, Umax, Ineg, and Iabs.
- Added comprehensive test cases to validate the functionality of these opcodes.
- Enhanced inline documentation and comments across the conversion module, including clarifications for convert_operands and convert_operands_w_rpo, and improvements to the conversion context.
- Refactored code for greater clarity and maintainability.